### PR TITLE
Add option to not send output, scroll to 07:00 at start

### DIFF
--- a/time-planner.html
+++ b/time-planner.html
@@ -59,7 +59,7 @@
 }
 	</pre>
 	<p>It can also take a url to download a updated schedule from a central server.
-	This URL will be polled every 10mins and will totally replace any manually 
+	This URL will be polled every 10mins and will totally replace any manually
 	configured events. The JSON format should look like this:</p>
 <pre>
 [
@@ -132,15 +132,16 @@
 				var id = events.length;
 
 				$('#calendar').weekCalendar({
-					date: new Date('2000-01-01T12:00:00.000+00:00'),
+					date: new Date('2009-05-03T07:45:00.000+00:00'),
 					minDate: new Date('2009-05-01T13:15:00.000+00:00'),
 					maxDate: new Date('2009-05-20T13:15:00.000+00:00'),
 					data: events,
-					timeslotHeight: 12,
+					timeslotHeight: 10,
 					timeslotsPerHour: 4,
 					defaultEventLength: 1,
 					use24Hour: true,
 					showHeader: false,
+                    textSize: 8,
 					getHeaderDate: function(date, element){
 						var d=['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 						return d[date.getDay()];
@@ -164,7 +165,7 @@
 					// beforeEventNew: function(calEvent, $event) {
 					// 	calEvent.id = id++;
 					// 	calEvent.title = "";
-					// }, 
+					// },
 					eventNew: function(calEvent, $event) {
 						calEvent.id = id++;
 						calEvent.title = "";
@@ -174,8 +175,8 @@
 					}
 				});
 
-
-				if(node.startPayloadType == null) {
+                var optionNothing = {value:"nul",label:"Nothing - no output",hasValue:false};
+				if (node.startPayloadType === null) {
 					node.startPayloadType = "str";
 				}
 				$("#node-input-startPayloadType").val(node.startPayloadType);
@@ -183,7 +184,7 @@
 				$("#node-input-startPayload").typedInput({
 					default: 'str',
 					typeField: $("#node-input-startPayloadType"),
-					types:['flow','global','str','num','bool','json']
+					types:['flow','global','str','num','bool','json',optionNothing]
 				});
 
 				if(node.endPayloadType == null) {
@@ -194,10 +195,8 @@
 				$("#node-input-endPayload").typedInput({
 					default: 'str',
 					typeField: $("#node-input-endPayloadType"),
-					types:['flow','global','str','num','bool','json']
+					types:['flow','global','str','num','bool','json',optionNothing]
 				});
-
-
 			}
 
 			$.getScript('time-planner/js/date.js')
@@ -228,7 +227,6 @@
 			delete window.calendar;
 		},
 		oneditresize: function() {
-
 		}
 	});
 </script>

--- a/time-planner.js
+++ b/time-planner.js
@@ -15,206 +15,201 @@
  **/
 
 module.exports = function(RED) {
-	"use strict";
-	var path = require('path');
-	var req = require('request');
+    "use strict";
+    var path = require('path');
+    var req = require('request');
 
-	var timePlanner = function(n) {
-		RED.nodes.createNode(this,n);
-		this.events = JSON.parse(n.events);
-		this.central = n.central;
-		this.topic = n.topic;
-		this.startPayload = n.startPayload;
-		this.startPayloadType = n.startPayloadType;
-		this.endPayload = n.endPayload;
-		this.endPayloadType = n.endPayloadType;
-		var node = this;
+    var timePlanner = function(n) {
+        RED.nodes.createNode(this,n);
+        this.events = JSON.parse(n.events);
+        this.central = n.central;
+        this.topic = n.topic;
+        this.startPayload = n.startPayload;
+        this.startPayloadType = n.startPayloadType;
+        this.endPayload = n.endPayload;
+        this.endPayloadType = n.endPayloadType;
+        var node = this;
 
-		//console.log(node.events);
+        function checkCentral() {
+            if (node.central) {
+                req(node.central, function(err, respose, body) {
+                    if (!err && response.statusCode === 200) {
+                        try { node.events = JSON.parse(body); }
+                        catch (error) { node.log(error); }
+                    }
+                    else { node.log(err, response.statusCode); }
+                });
+            }
+        }
 
-		function checkCentral() {
-			if (node.central) {
-				req(node.central, function(err, respose, body){
-					if (!err && response.statusCode == 200) {
-						try{
-							node.events = JSON.parse(body);
-						} catch (error) {
-							//problem with the events returned
-							node.log(error);
-						}
-					} else {
-						node.log(err, response.statusCode);
-					}
-				});
-			}
-		}
+        function firstTime() {
+            var now = new Date();
+            var day = now.getUTCDay();
+            var hour = now.getUTCHours();
+            var mins = now.getUTCMinutes();
+            // console.log("firstTime now: " + now.toISOString());
+            // console.log("firstTime day: " + day);
+            // console.log("firstTime hour: " + hour);
+            // console.log("firstTime min: " + mins);
+            var found = false;
+            for (var i=0; i< node.events.length; i++) {
+                var evtStart = new Date();
+                evtStart.setTime(Date.parse(node.events[i].start));
+                // console.log("firstTime evtStart: " + evtStart.toISOString());
+                // console.log("firstTime evtStart day: " + evtStart.getUTCDay());
+                // console.log("firstTime evtStart hour: " + evtStart.getUTCHours());
+                // console.log("firstTime evtStart min: " + evtStart.getUTCMinutes());
+                var evtEnd = new Date();
+                evtEnd.setTime(Date.parse(node.events[i].end));
 
-		function firstTime(){
-			var now = new Date();
-			var day = now.getUTCDay();
-			var hour = now.getUTCHours();
-			var mins = now.getUTCMinutes();
-			// console.log("firstTime now: " + now.toISOString());
-			// console.log("firstTime day: " + day);
-			// console.log("firstTime hour: " + hour);
-			// console.log("firstTime min: " + mins);
+                if (evtStart.getUTCDay() === day) {
+                    //same day
+                    evtStart.setFullYear(now.getFullYear(), now.getUTCMonth(), now.getUTCDate());
+                    evtEnd.setFullYear(now.getFullYear(), now.getUTCMonth(), now.getUTCDate());
+                    if (hour >= evtStart.getUTCHours()) {
+                        //after or same start hour
+                        if (hour === evtStart.getUTCHours) {
+                            if (mins >= evtStart.getUTCMinutes()) {
+                                //same hour and same or after start mins
+                                if (hour <= evtEnd.getUTCHours()) {
+                                    //before or equal to end hour
+                                    if (hour < evtEnd.getUTCHours) {
+                                        //in event
+                                        sendStartMessage(evtStart,evtEnd);
+                                        found = true;
+                                        break;
+                                    }
+                                    else if (hour === evtEnd.getUTCHours()) {
+                                        if (mins <= evtEnd.getUTCMinutes()) {
+                                            //in event
+                                            sendStartMessage(evtStart, evtEnd);
+                                            found = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else {
+                            //after start
+                            if (hour <= evtEnd.getUTCHours()) {
+                                //before or same to end hour
+                                if (hour === evtEnd.getUTCHours()) {
+                                    //same hour as end
+                                    if (mins <= evtEnd.getUTCMinutes()) {
+                                        //in event
+                                        sendStartMessage(evtStart,evtEnd);
+                                        found = true;
+                                        break;
+                                    }
+                                }
+                                else if (hour < evtEnd.getUTCHours()) {
+                                    //in event
+                                    sendStartMessage(evtStart,evtEnd);
+                                    found = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            if (!found) { sendEndMessage(); }
+        }
 
-			var found = false;
-			for (var i=0; i< node.events.length; i++) {
-				var evtStart = new Date();
-				evtStart.setTime(Date.parse(node.events[i].start));
-				// console.log("firstTime evtStart: " + evtStart.toISOString());
-				// console.log("firstTime evtStart day: " + evtStart.getUTCDay());
-				// console.log("firstTime evtStart hour: " + evtStart.getUTCHours());
-				// console.log("firstTime evtStart min: " + evtStart.getUTCMinutes());
-				var evtEnd =  new Date();
-				evtEnd.setTime(Date.parse(node.events[i].end));
+        function sendStartMessage(evtStart,evtEnd) {
+            console.log("sendStartMessage");
+            var now = new Date();
+            // evtStart.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
+            // evtEnd.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
+            if (node.startPayloadType !== "nul") {
+                var msg = {
+                    topic: node.topic,
+                    event: {
+                        start:evtStart.toTimeString(),
+                        end: evtEnd.toTimeString()
+                    },
+                    payload: RED.util.evaluateNodeProperty(node.startPayload, node.startPayloadType, node, msg)
+                };
+                setTimeout(function() {
+                    node.send(msg);
+                }, 500);
+            }
+        }
 
-				if (evtStart.getUTCDay() == day) {
-					//same day
-					evtStart.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
-					evtEnd.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
-					if (hour >= evtStart.getUTCHours()) {
-						//after or same start hour
-						if (hour === evtStart.getUTCHours){
-							if (mins >= evtStart.getUTCMinutes()) {
-								//same hour and same or after start mins
-								if (hour <= evtEnd.getUTCHours()) {
-									//before or equal to end hour
-									if (hour < evtEnd.getUTCHours){
-										//in event
-										sendStartMessage(evtStart,evtEnd);
-										found = true;
-										break;
-									} else if (hour === evtEnd.getUTCHours()){
-										if (mins <= evtEnd.getUTCMinutes()) {
-											//in event
-											sendStartMessage(evtStart, evtEnd);
-											found = true;
-											break;
-										}
-									}
-								}
-							}
-						} else {
-							//after start
-							if (hour <= evtEnd.getUTCHours()) {
-								//before or same to end hour
-								if (hour === evtEnd.getUTCHours()) {
-									//same hour as end
-									if (mins <= evtEnd.getUTCMinutes()) {
-										//in event
-										sendStartMessage(evtStart,evtEnd);
-										found = true;
-										break;
-									}
-								} else if (hour < evtEnd.getUTCHours()){
-									//in event
-									sendStartMessage(evtStart,evtEnd);
-									found = true;
-									break;
-								}
-							}
-						}
-					}
-				} 
-			}
+        function sendEndMessage() {
+            console.log("sendEndMessage");
+            if (node.endPayloadType !== "nul") {
+                var msg = {
+                    topic: node.topic,
+                    payload: RED.util.evaluateNodeProperty(node.endPayload, node.endPayloadType, node,msg)
+                }
+                setTimeout(function() {
+                    node.send(msg);
+                }, 500);
+            }
+        }
 
-			if (!found) {
-				sendEndMessage();
-			}
-		};
+        firstTime();
 
-		function sendStartMessage(evtStart,evtEnd){
+        function checkTime() {
+            var now = new Date();
+            var day = now.getUTCDay();
+            var hour = now.getUTCHours();
+            var mins = now.getUTCMinutes();
+            for (var i=0; i< node.events.length; i++) {
+                var evtStart = new Date();
+                evtStart.setTime(Date.parse(node.events[i].start));
+                var evtEnd = new Date();
+                evtEnd.setTime(Date.parse(node.events[i].end));
 
-			// console.log("sendStartMessage");
+                if (evtStart.getUTCDay() === day) { //same day of week
+                    evtStart.setFullYear(now.getFullYear(), now.getUTCMonth(), now.getUTCDate());
+                    evtEnd.setFullYear(now.getFullYear(), now.getUTCMonth(), now.getUTCDate());
 
-			var now = new Date();
-			// evtStart.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
-			// evtEnd.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
+                    var msg = {
+                        topic: node.topic,
+                        event: {
+                            start: evtStart.toTimeString(),
+                            end: evtEnd.toTimeString()
+                        }
+                    };
+                    if (hour === evtStart.getUTCHours() && mins === evtStart.getUTCMinutes()) {
+                        console.log("start");
+                        if (node.startPayloadType !== "nul") {
+                            msg.payload = RED.util.evaluateNodeProperty(node.startPayload, node.startPayloadType, node, msg);
+                            node.send(msg);
+                        }
+                    }
+                    if (hour === evtEnd.getUTCHours() && mins === evtEnd.getUTCMinutes()) {
+                        console.log("end");
+                        if (node.endPayloadType !== "nul") {
+                            msg.payload = RED.util.evaluateNodeProperty(node.endPayload, node.endPayloadType, node,msg);
+                            node.send(msg);
+                        }
+                    }
+                }
+            }
+        }
 
-			var msg = {
-				topic: node.topic,
-				event: {
-					start:evtStart.toTimeString(),
-					end: evtEnd.toTimeString()
-				},
-				payload: RED.util.evaluateNodeProperty(node.startPayload, node.startPayloadType, node,msg)
-			};
-			setTimeout(function(){
-				node.send(msg);
-			},500);
-		}
+        node.centralInterval = setInterval(function() { checkCentral(); }, 600000); //once every 10mins
+        node.interval = setInterval(function() { checkTime(); }, 60000); //once a min
+        //checkTime();
 
-		function sendEndMessage() {
-			var msg = {
-				topic: node.topic,
-				payload: RED.util.evaluateNodeProperty(node.endPayload, node.endPayloadType, node,msg)
-			}
-			setTimeout(function(){
-				node.send(msg);
-			},500);
-		}
+        node.on('close', function() {
+            clearInterval(node.centralInterval);
+            clearInterval(node.interval);
+        });
+    }
+    RED.nodes.registerType("time-planner",timePlanner);
 
-		firstTime();
-
-		function checkTime(){
-			var now = new Date();
-			var day = now.getUTCDay();
-			var hour = now.getUTCHours();
-			var mins = now.getUTCMinutes();
-			for (var i=0; i< node.events.length; i++) {
-				var evtStart = new Date();
-				evtStart.setTime(Date.parse(node.events[i].start));
-				var evtEnd =  new Date();
-				evtEnd.setTime(Date.parse(node.events[i].end));
-
-
-				if (evtStart.getUTCDay() === day) { //same day of week
-					evtStart.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
-					evtEnd.setFullYear(now.getFullYear(),now.getUTCMonth(), now.getUTCDate());
-
-					var msg = {
-						topic: node.topic,
-						event: {
-							start:evtStart.toTimeString(),
-							end: evtEnd.toTimeString()
-						}
-					};
-					if (hour === evtStart.getUTCHours() && mins === evtStart.getUTCMinutes()) {
-						// console.log("start");
-						msg.payload = RED.util.evaluateNodeProperty(node.startPayload, node.startPayloadType, node,msg);
-						node.send(msg);
-					}
-					if (hour === evtEnd.getUTCHours() && mins === evtEnd.getUTCMinutes()) {
-						// console.log("end");
-						msg.payload = RED.util.evaluateNodeProperty(node.endPayload, node.endPayloadType, node,msg);
-						node.send(msg);
-					}
-				}
-			}
-		}
-
-		node.centralInterval = setInterval(checkCentral,600000); //once every 10mins
-
-		node.interval = setInterval(checkTime,60000); //once a min
-		checkTime();
-
-		node.on('close', function(){
-			clearInterval(node.centralInterval);
-			clearInterval(node.interval);
-		});
-
-	};
-	RED.nodes.registerType("time-planner",timePlanner);
-
-	RED.httpAdmin.get('/time-planner/js/*', function(req,res){
-		// var filename = path.join(__dirname , 'static', req.params[0]);
-		// res.sendfile(filename);
-		var options = {
-			root: __dirname + '/static/',
-			dotfiles: 'deny'
-		};
- 		res.sendFile(req.params[0], options);
-	});
+    RED.httpAdmin.get('/time-planner/js/*', function(req,res) {
+        // var filename = path.join(__dirname , 'static', req.params[0]);
+        // res.sendfile(filename);
+        var options = {
+            root: __dirname + '/static/',
+            dotfiles: 'deny'
+        };
+        res.sendFile(req.params[0], options);
+    });
 };


### PR DESCRIPTION
Hi,
Added an option to not send an output at the designated time (so you can send only on events for example). 
Also set the start time to be 07:45 on day 1 so the main part of the day scrolls into view.
And shrunk the event text height and size slightly to try to get most of a day into the edit config window.

Apologies for the complete .js file replace... was a tab vs space thing... 